### PR TITLE
Explicitly specify the version of tree-sitter-make

### DIFF
--- a/docs/resources/configure.md
+++ b/docs/resources/configure.md
@@ -109,11 +109,11 @@ vim.api.nvim_create_autocmd({ "BufEnter" }, {
 ```toml
 [[language]]
 name = "autoconf"
-language-servers = [ "autoconf-language-server",]
+language-servers = ["autoconf-language-server"]
 
 [[language]]
 name = "make"
-language-servers = [ "make-language-server",]
+language-servers = ["make-language-server"]
 
 [language_server.autoconf-language-server]
 command = "autoconf-language-server"
@@ -130,11 +130,11 @@ command = "make-language-server"
 
 ```toml
 [language_server.autoconf-language-server]
-filetypes = [ "autoconf",]
+filetypes = ["autoconf"]
 command = "autoconf-language-server"
 
 [language_server.make-language-server]
-filetypes = [ "make",]
+filetypes = ["make"]
 command = "make-language-server"
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S pip install -r
 
 lsp-tree-sitter >= 0.0.16
-tree-sitter-make
+tree-sitter-make == 0.0.1


### PR DESCRIPTION
Fix #8

tree-sitter-make has only yanked version (0.0.1).
We can install it by explicitly specifying the version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version specification for the `tree-sitter-make` package to version `0.0.1`.
- **Documentation**
	- Revised configuration paths for Windows and macOS in `configure.md`.
	- Updated Vim configuration paths and file names for clarity.
	- Standardized formatting for language server configurations across various editors.
	- Improved presentation of configurations for Helix, Kakoune, Sublime, and Visual Studio Code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->