### PR TITLE
feat(make-language-server): add textDocument/documentSymbol support

### DIFF
--- a/src/make_language_server/assets/queries/symbols.scm
+++ b/src/make_language_server/assets/queries/symbols.scm
@@ -1,0 +1,19 @@
+; Document symbols query for Makefiles
+; Captures targets (rules), variables, and define directives (functions)
+
+; Targets/Rules
+(rule
+  (targets
+    (word) @target.name
+    )
+  ) @target
+
+; Variable assignments
+(variable_assignment
+  name: (word) @variable.name
+  ) @variable
+
+; Define directives (multi-line functions/macros)
+(define_directive
+  name: (word) @function.name
+  ) @function

--- a/src/make_language_server/finders.py
+++ b/src/make_language_server/finders.py
@@ -418,7 +418,11 @@ class DocumentSymbolFinder:
                     kind = SymbolKind.Variable
 
                 # Get the name text
-                name = matching_name.text.decode("utf-8") if matching_name.text else ""
+                name = (
+                    matching_name.text.decode("utf-8")
+                    if matching_name.text
+                    else ""
+                )
 
                 # Skip special targets (like .PHONY)
                 if name.startswith(".") and name.isupper():

--- a/src/make_language_server/finders.py
+++ b/src/make_language_server/finders.py
@@ -4,6 +4,7 @@ r"""Finders
 
 import os
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from lsp_tree_sitter import UNI
 from lsp_tree_sitter.finders import (
@@ -11,10 +12,17 @@ from lsp_tree_sitter.finders import (
     QueryFinder,
     RepeatedFinder,
 )
-from lsprotocol.types import DiagnosticSeverity
+from lsprotocol.types import (
+    DiagnosticSeverity,
+    DocumentSymbol,
+    SymbolKind,
+)
 from tree_sitter import Node, Tree
 
 from .utils import get_query, parser
+
+if TYPE_CHECKING:
+    from lsprotocol.types import Range
 
 
 @dataclass(init=False)
@@ -307,3 +315,121 @@ DIAGNOSTICS_FINDER_CLASSES = [
     InvalidPathFinder,
     RepeatedTargetFinder,
 ]
+
+
+def _node_to_range(node: Node, uri: str) -> "Range":
+    r"""Convert tree-sitter node to LSP Range.
+
+    :param node:
+    :type node: Node
+    :param uri:
+    :type uri: str
+    :rtype: Range
+    """
+    from lsprotocol.types import Position, Range
+
+    return Range(
+        start=Position(
+            line=node.start_point[0],
+            character=node.start_point[1],
+        ),
+        end=Position(
+            line=node.end_point[0],
+            character=node.end_point[1],
+        ),
+    )
+
+
+class DocumentSymbolFinder:
+    r"""Finder for document symbols (targets, variables, functions)."""
+
+    def __init__(self) -> None:
+        r"""Init."""
+        from tree_sitter import QueryCursor
+
+        self.query = get_query("symbols")
+        self.cursor = QueryCursor(self.query)
+
+    @staticmethod
+    def _is_descendant_of(node: Node, container: Node) -> bool:
+        r"""Check if node is a descendant of container.
+
+        :param node:
+        :type node: Node
+        :param container:
+        :type container: Node
+        :rtype: bool
+        """
+        current = node
+        while current is not None:
+            if current.id == container.id:
+                return True
+            current = current.parent
+        return False
+
+    def find_all(self, uri: str, tree: Tree) -> list[DocumentSymbol]:
+        r"""Find all document symbols in the tree.
+
+        :param uri:
+        :type uri: str
+        :param tree:
+        :type tree: Tree
+        :rtype: list[DocumentSymbol]
+        """
+        symbols: list[DocumentSymbol] = []
+        captures = self.cursor.captures(tree.root_node)
+
+        # Collect containers and names separately
+        containers: dict[str, list[Node]] = {}
+        names: dict[str, list[Node]] = {}
+
+        for capture_name, nodes in captures.items():
+            if "." in capture_name:
+                # This is a name capture like "target.name"
+                names[capture_name] = nodes
+            else:
+                # This is a container capture like "target", "variable", "function"
+                containers[capture_name] = nodes
+
+        # Match each container with its corresponding name
+        for symbol_type, container_nodes in containers.items():
+            name_key = f"{symbol_type}.name"
+            name_nodes = names.get(name_key, [])
+
+            for container in container_nodes:
+                # Find the name node that belongs to this container
+                matching_name = None
+                for name_node in name_nodes:
+                    if self._is_descendant_of(name_node, container):
+                        matching_name = name_node
+                        break
+
+                if matching_name is None:
+                    continue
+
+                # Determine symbol kind based on type
+                if symbol_type == "target":
+                    kind = SymbolKind.Function
+                elif symbol_type == "variable":
+                    kind = SymbolKind.Variable
+                elif symbol_type == "function":
+                    kind = SymbolKind.Function
+                else:
+                    kind = SymbolKind.Variable
+
+                # Get the name text
+                name = matching_name.text.decode("utf-8") if matching_name.text else ""
+
+                # Skip special targets (like .PHONY)
+                if name.startswith(".") and name.isupper():
+                    continue
+
+                symbol = DocumentSymbol(
+                    name=name,
+                    kind=kind,
+                    range=_node_to_range(container, uri),
+                    selection_range=_node_to_range(matching_name, uri),
+                )
+                symbols.append(symbol)
+
+        return symbols

--- a/src/make_language_server/server.py
+++ b/src/make_language_server/server.py
@@ -12,6 +12,7 @@ from lsprotocol.types import (
     TEXT_DOCUMENT_DEFINITION,
     TEXT_DOCUMENT_DID_CHANGE,
     TEXT_DOCUMENT_DID_OPEN,
+    TEXT_DOCUMENT_DOCUMENT_SYMBOL,
     TEXT_DOCUMENT_HOVER,
     TEXT_DOCUMENT_REFERENCES,
     CompletionItem,
@@ -19,6 +20,8 @@ from lsprotocol.types import (
     CompletionList,
     CompletionParams,
     DidChangeTextDocumentParams,
+    DocumentSymbol,
+    DocumentSymbolParams,
     Hover,
     Location,
     MarkupContent,
@@ -33,6 +36,7 @@ from pygls.lsp.server import LanguageServer
 from .finders import (
     DIAGNOSTICS_FINDER_CLASSES,
     DefinitionFinder,
+    DocumentSymbolFinder,
     ReferenceFinder,
 )
 from .utils import get_schema, parser
@@ -123,6 +127,29 @@ class MakeLanguageServer(LanguageServer):
                     document.uri, self.trees[document.uri]
                 )
             ]
+
+        @self.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)
+        def document_symbol(
+            params: DocumentSymbolParams,
+        ) -> list[DocumentSymbol]:
+            r"""Get document symbols.
+
+            Returns all symbols (targets, variables, functions) defined in
+            the document.
+
+            :param params:
+            :type params: DocumentSymbolParams
+            :rtype: list[DocumentSymbol]
+            """
+            document = self.workspace.get_text_document(
+                params.text_document.uri
+            )
+            if document.uri not in self.trees:
+                # Parse the document if not already parsed
+                self.trees[document.uri] = parser.parse(document.source.encode())
+            return DocumentSymbolFinder().find_all(
+                document.uri, self.trees[document.uri]
+            )
 
         @self.feature(TEXT_DOCUMENT_HOVER)
         def hover(params: TextDocumentPositionParams) -> Hover | None:

--- a/src/make_language_server/server.py
+++ b/src/make_language_server/server.py
@@ -146,7 +146,9 @@ class MakeLanguageServer(LanguageServer):
             )
             if document.uri not in self.trees:
                 # Parse the document if not already parsed
-                self.trees[document.uri] = parser.parse(document.source.encode())
+                self.trees[document.uri] = parser.parse(
+                    document.source.encode()
+                )
             return DocumentSymbolFinder().find_all(
                 document.uri, self.trees[document.uri]
             )


### PR DESCRIPTION
## Summary

This PR adds `textDocument/documentSymbol` support to the make-language-server, enabling IDE integration features like document outlines and breadcrumb navigation for Makefiles.

### Changes

- Added new tree-sitter query file (`symbols.scm`) to capture:
  - Target definitions (rules)
  - Variable assignments
  - Define directives (multi-line functions/macros)
- Added `DocumentSymbolFinder` class in `finders.py` to process query captures
- Added `textDocument/documentSymbol` handler in `server.py`

### Symbol Types

| Makefile Element | LSP SymbolKind |
|------------------|----------------|
| Targets (rules)  | Function       |
| Variables        | Variable       |
| Define macros    | Function       |

### Example

For a Makefile like:
```makefile
CC = gcc
CFLAGS = -Wall

all: program
    @echo "Done"

clean:
    rm -f *.o
```

The server now returns symbols:
- `CC` (Variable)
- `CFLAGS` (Variable)
- `all` (Function)
- `clean` (Function)

### Testing

Tested locally with:
- Simple Makefiles
- Complex Makefiles with define directives
- Pattern rules (e.g., `%.o: %.c`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document Symbol Support: The language server now exposes Makefile symbols—targets (rules), variable assignments, and multi-line define directives—so IDEs can show them in the symbol outline, breadcrumbs, and symbol search for easier navigation and code understanding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->